### PR TITLE
fix: set baseUrl correctly for information widget

### DIFF
--- a/src/components/dashboardItem.component.tsx
+++ b/src/components/dashboardItem.component.tsx
@@ -15,6 +15,11 @@ function setupResize(ref:RefObject<HTMLObjectElement>){
     window.addEventListener('resize',()=>resizeObject(ref.current));
 }
 
+function getBaseUrl() {
+    const {origin, pathname} = window.location
+    return origin + pathname.substring(0, pathname.indexOf('/api'))
+}
+
 export function DashboardItemComponent({dashboardItem}:{dashboardItem:DashboardItem}){
     const objectRef=useRef<HTMLObjectElement>(null);
     useEffect(()=>setupResize(objectRef));
@@ -22,7 +27,7 @@ export function DashboardItemComponent({dashboardItem}:{dashboardItem:DashboardI
         <Paper className={'Paper'}>
             <object
                 ref={objectRef}
-                data={`/api/apps/Information/index.html?dashboardItemId=${dashboardItem.id}#/`}
+                data={`${getBaseUrl()}/api/apps/Information/index.html?dashboardItemId=${dashboardItem.id}#/`}
                 type={'text/html'}
             />
         </Paper>


### PR DESCRIPTION
For instances where tomcat is hosted on a subdirectory of the top level domain (for example https://play.dhis2.org/2.38.2.1). The app misses the subdirectory when making requests to the Information widget, causing them to not render. I have added in a small code snipped to get the base url correctly.